### PR TITLE
Change reserved_concurrent_executions for aws lambda to 0

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -65,7 +65,7 @@ resource "aws_lambda_function" "lambda_function" {
   memory_size                    = 256
   runtime                        = "go1.x"
   timeout                        = 60
-  reserved_concurrent_executions = 1
+  reserved_concurrent_executions = 0
 
   environment {
     variables = {


### PR DESCRIPTION
On listing 11.13 in manning-code, i got this error from `terraform apply`:
```
module.petstore.module.lambda.aws_lambda_function.lambda_function: Creating...
module.petstore.module.lambda.aws_lambda_function.lambda_function: Still creating... [10s elapsed]
module.petstore.module.lambda.aws_lambda_function.lambda_function: Still creating... [20s elapsed]
module.petstore.module.lambda.aws_lambda_function.lambda_function: Still creating... [30s elapsed]
╷
│ Error: error setting Lambda Function (petstore-uehxltb3lt4xqvw-lambda) concurrency: InvalidParameterValueException: Specified ReservedConcurrentExecutions for function decreases account's UnreservedConcurrentExecution below its minimum value of [50].
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "4e853e3b-6430-419f-809e-400f49bcb2c2"
│   },
│   Message_: "Specified ReservedConcurrentExecutions for function decreases account's UnreservedConcurrentExecution below its minimum value of [50]."
│ }
│ 
│   with module.petstore.module.lambda.aws_lambda_function.lambda_function,
│   on .terraform/modules/petstore/modules/lambda/main.tf line 60, in resource "aws_lambda_function" "lambda_function":
│   60: resource "aws_lambda_function" "lambda_function" {
│ 
╵
```

after:
```
module.petstore.module.lambda.aws_lambda_function.lambda_function: Creating...
module.petstore.module.lambda.aws_lambda_function.lambda_function: Still creating... [10s elapsed]
module.petstore.module.lambda.aws_lambda_function.lambda_function: Still creating... [20s elapsed]
module.petstore.module.lambda.aws_lambda_function.lambda_function: Creation complete after 29s [id=petstore-uehxltb3lt4xqvw-lambda]
module.petstore.module.apigw.aws_api_gateway_integration.any_method_integration: Creating...
module.petstore.module.apigw.aws_lambda_permission.lambda_permission_api_gateway: Creating...
module.petstore.module.apigw.aws_lambda_permission.lambda_permission_api_gateway: Creation complete after 1s [id=AllowExecutionFromAPIGateway]
module.petstore.module.apigw.aws_api_gateway_integration.any_method_integration: Creation complete after 1s [id=agi-8chpirn0h0-1sbkvx-ANY]
module.petstore.module.apigw.aws_api_gateway_deployment.api_deployment: Creating...
module.petstore.module.apigw.aws_api_gateway_deployment.api_deployment: Creation complete after 1s [id=eg0wo5]

Apply complete! Resources: 4 added, 0 changed, 1 destroyed.

Outputs:

address = "https://8chpirn0h0.execute-api.us-west-2.amazonaws.com/v1"

```

this might affect some behavior, so welcome any criticism